### PR TITLE
add github link to book.toml

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -6,3 +6,5 @@ title = "MRX Book"
 
 [output.html]
 mathjax-support = true
+site-url = "/mrx-book/"
+git-repository-url = "https://github.com/mrx-org/mrx-book"


### PR DESCRIPTION
add git-repository-url to book.toml so that a link to the repository is visible in the book